### PR TITLE
Increasing Heap size to 128k

### DIFF
--- a/source/border_router.cpp
+++ b/source/border_router.cpp
@@ -35,7 +35,8 @@
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
 
-#define APP_DEFINED_HEAP_SIZE 32500
+#define APP_DEFINED_HEAP_SIZE 128500
+
 static uint8_t app_stack_heap[APP_DEFINED_HEAP_SIZE];
 static uint8_t mac[6] = {0};
 


### PR DESCRIPTION
It is evident from the memory map, that out of 256k ram,
we allocate only 32k to the BR. As this k64f-BR is specific to k64f platform,
we can afford to increase the heap size. Anything left after heap allocation to
nanostack is then given to other heap managers like dlmalloc of mbedOS.